### PR TITLE
Added count method into repository class

### DIFF
--- a/src/ORM/Interfaces/RepositoryInterface.php
+++ b/src/ORM/Interfaces/RepositoryInterface.php
@@ -6,6 +6,17 @@ namespace EoneoPay\Externals\ORM\Interfaces;
 interface RepositoryInterface
 {
     /**
+     * Counts entities by a set of criteria.
+     *
+     * @param mixed[]|null $criteria
+     *
+     * @return int The cardinality of the objects that match the given criteria.
+     *
+     * @throws \EoneoPay\Externals\ORM\Exceptions\ORMException
+     */
+    public function count(?array $criteria = null): int;
+
+    /**
      * Find a entity by its primary key / identifier
      *
      * @param mixed $entityId The primary identifier for the entity

--- a/src/ORM/Repository.php
+++ b/src/ORM/Repository.php
@@ -20,6 +20,14 @@ class Repository extends SimpleOrmDecorator implements RepositoryInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function count(?array $criteria = null): int
+    {
+        return $this->callMethod('count', $criteria ?? []);
+    }
+
+    /**
      * Find an entity by its primary key / identifier
      *
      * @param mixed $entityId The primary identifier for the entity

--- a/tests/ORM/EntityManagerTest.php
+++ b/tests/ORM/EntityManagerTest.php
@@ -213,6 +213,7 @@ class EntityManagerTest extends DoctrineTestCase
         self::assertInstanceOf(EntityStub::class, $repository->findOneBy(['string' => 'string']));
         self::assertCount(1, $repository->findAll());
         self::assertCount(1, $repository->findBy(['string' => 'string']));
+        self::assertEquals(1, $repository->count());
     }
 
     /**


### PR DESCRIPTION
To make funky codes such as 

```php
$this->getEntityManager()->getRepository(SomeEntity::class)->count(); // 100000
$this->getEntityManager()->getRepository(SomeEntity::class)->count(['email' => 'some@thing.com']); // 1
```

Doctrine has not added the `count` method to their ObjectRepository interface, however they will be doing so next major release - for forwards compatibility I've included it in our interface.

```     * @todo Add this method to `ObjectRepository` interface in the next major release```
https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/EntityRepository.php#L152