### PR TITLE
EntityFactoryManager not to cache entities that have no properties

### DIFF
--- a/tests/ORM/EntityFactoryManagerTest.php
+++ b/tests/ORM/EntityFactoryManagerTest.php
@@ -8,6 +8,7 @@ use EoneoPay\Externals\ORM\Exceptions\InvalidArgumentException;
 use Tests\EoneoPay\Externals\EntityFactoryManagerTestCase;
 use Tests\EoneoPay\Externals\ORM\Stubs\EntityCustomRepository;
 use Tests\EoneoPay\Externals\ORM\Stubs\EntityStub;
+use Tests\EoneoPay\Externals\ORM\Stubs\EntityWithNoPropertiesStub;
 use Tests\EoneoPay\Externals\ORM\Stubs\EntityWithRulesStub;
 
 class EntityFactoryManagerTest extends EntityFactoryManagerTestCase
@@ -47,6 +48,29 @@ class EntityFactoryManagerTest extends EntityFactoryManagerTestCase
             ['integer' => 1, 'string' => 'string'],
             $entityFactoryManager->getDefaultData(EntityStub::class)
         );
+    }
+
+    /**
+     * EntityFactoryManager should not cache entities that have not been provided data.
+     *
+     * @return void
+     *
+     * @throws \Doctrine\Common\Annotations\AnnotationException
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \EoneoPay\Externals\ORM\Exceptions\EntityValidationFailedException
+     * @throws \EoneoPay\Externals\ORM\Exceptions\InvalidArgumentException
+     * @throws \EoneoPay\Externals\ORM\Exceptions\ORMException
+     */
+    public function testCreateTwiceNoDataDifferentObject(): void
+    {
+        $entityFactoryManager = $this->getEntityFactoryManager([
+            'Tests\EoneoPay\Externals\ORM\Stubs\Factories\\' => 'Tests\EoneoPay\Externals\ORM\Stubs'
+        ]);
+
+        $entity1 = $entityFactoryManager->create(EntityWithNoPropertiesStub::class);
+        $entity2 = $entityFactoryManager->create(EntityWithNoPropertiesStub::class);
+
+        self::assertNotEquals(\spl_object_id($entity1), \spl_object_id($entity2));
     }
 
     /**

--- a/tests/ORM/Stubs/EntityWithNoPropertiesStub.php
+++ b/tests/ORM/Stubs/EntityWithNoPropertiesStub.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\Externals\ORM\Stubs;
+
+use Doctrine\ORM\Mapping as ORM;
+use EoneoPay\Externals\ORM\Entity;
+
+/**
+ * @method string getEntityId()
+ * @method self setEntityId(string $entityId)
+ *
+ * The following methods are only used for testing validity of __call
+ * @method string|null getAnnotationName()
+ * @method null getInvalid()
+ * @method self setAnnotationName(string $name)
+ * @method null whenString()
+ *
+ * @ORM\Entity()
+ */
+class EntityWithNoPropertiesStub extends Entity
+{
+    /**
+     * Primary id
+     *
+     * @var string
+     *
+     * @ORM\Column(type="string", length=36)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="UUID")
+     */
+    protected $entityId;
+
+    /**
+     * Serialize entity as an array
+     *
+     * @return mixed[]
+     */
+    public function toArray(): array
+    {
+        return [
+            'entityId' => $this->entityId
+        ];
+    }
+}

--- a/tests/ORM/Stubs/Factories/EntityWithNoPropertiesStubEntityFactory.php
+++ b/tests/ORM/Stubs/Factories/EntityWithNoPropertiesStubEntityFactory.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\Externals\ORM\Stubs\Factories;
+
+use EoneoPay\Externals\ORM\EntityFactory;
+use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
+use Tests\EoneoPay\Externals\ORM\Stubs\EntityWithNoPropertiesStub;
+
+class EntityWithNoPropertiesStubEntityFactory extends EntityFactory
+{
+    /**
+     * Create an entity.
+     *
+     * @param mixed[] $data
+     *
+     * @return \EoneoPay\Externals\ORM\Interfaces\EntityInterface
+     */
+    public function create(array $data): EntityInterface
+    {
+        return new EntityWithNoPropertiesStub($data);
+    }
+
+    /**
+     * Get default date used for test.
+     *
+     * @return mixed[]
+     */
+    public function getDefaultData(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Added fix for Entity Factory Manager to not cache entities if no construct data was provided.

This only affects entities that have no default data defined in the entity factory, and when `create([])` is called without any array items.

eg.
```php
// SomeEntity = Entity with no properties, just a PK
// SomeEntity::getDefaultData() = []

$entity = $this->getEntityFactoryManager()->create(SomeEntity::class);
$entity2 = $this->getEntityFactoryManager()->create(SomeEntity::class);

// Previously $entity->getId() === $entity2->getId()
```