### PR TITLE
Allow guarded or non-fillable properties to be set using setter methods.

### DIFF
--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -50,7 +50,7 @@ abstract class Entity implements EntityInterface
 
         // The property being accessed must exist and the type must be valid if one of these things
         // aren't true throw an exception
-        if ($type === '' || $property === null || ($type === 'set' && $this->isFillable($property) === false)) {
+        if ($type === '' || $property === null) {
             throw new InvalidMethodCallException(
                 \sprintf('Call to undefined method %s::%s()', \get_class($this), $method)
             );
@@ -79,6 +79,11 @@ abstract class Entity implements EntityInterface
     {
         // Loop through data and set values, set will automatically skip invalid or non-fillable properties
         foreach ($data as $property => $value) {
+            // Skip set if property is not fillable.
+            if ($this->isFillable($property) === false) {
+                continue;
+            }
+
             $this->set($property, $value);
         }
     }
@@ -492,8 +497,8 @@ abstract class Entity implements EntityInterface
     {
         $resolved = (string)$this->resolveProperty($property);
 
-        // If property doesn't exist or is not fillable, return
-        if ($this->has($property) === false || $this->isFillable($resolved) === false) {
+        // If property doesn't exist, return
+        if ($this->has($property) === false) {
             return $this;
         }
 

--- a/tests/ORM/EntityTest.php
+++ b/tests/ORM/EntityTest.php
@@ -259,6 +259,30 @@ class EntityTest extends ORMTestCase
     }
 
     /**
+     * Test guarded property can still be set using setter method.
+     *
+     * @return void
+     */
+    public function testGuardCanStillBeSetWithSetterMethod(): void
+    {
+        $entity = new GuardedStub();
+
+        // Fill entity with data excluding entityId
+        $data = self::$data;
+        $data['entityId'] = 'skipped-entity-value';
+        $entity->fill($data);
+
+        // Ensure that entityId is still null.
+        self::assertNull($entity->getEntityId());
+
+        // Call setter method (proceeds to __call)
+        $entity->setEntityId('the-entity-id');
+
+        // Test that property is set using setter method even if entityId is guarded.
+        self::assertEquals('the-entity-id', $entity->getEntityId());
+    }
+
+    /**
      * Test guarded prevents filling certain fields
      *
      * @return void

--- a/tests/TestCases/ORMTestCase.php
+++ b/tests/TestCases/ORMTestCase.php
@@ -96,6 +96,21 @@ abstract class ORMTestCase extends TestCase
     private $seeded = false;
 
     /**
+     * Require the annotations for doctrine and extensions.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Require Doctrine annotations
+        require_once __DIR__ . '/../../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php';
+        // Require Gedmo annotations
+        require_once __DIR__ . '/../../vendor/gedmo/doctrine-extensions/lib/Gedmo/Mapping/Annotation/All.php';
+    }
+
+    /**
      * Lazy load database schema only when required
      *
      * @return void


### PR DESCRIPTION
- Moved fillable check to `fill` method to allow setter methods to set properties even if property is guarded or not fillable. Updated test.
- Added require doctrine annotations and extensions in `ORMTestcase` for tests to pass.

See #75 