### PR TITLE
PYMT-1014: Guzzle Timeout

### DIFF
--- a/src/HttpClient/ClientOptions.php
+++ b/src/HttpClient/ClientOptions.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Externals\HttpClient;
+
+use EoneoPay\Externals\HttpClient\Interfaces\ClientOptionsInterface;
+use GuzzleHttp\RequestOptions;
+
+class ClientOptions implements ClientOptionsInterface
+{
+    /**
+     * @var float The number of seconds the HTTP client will wait to connect.
+     */
+    private $connectTimeout = 5;
+
+    /**
+     * @var int The number of seconds the HTTP client will wait for the response body to
+     *          stream before timing out.
+     */
+    private $readTimeout = 0;
+
+    /**
+     * @var float The number of seconds the HTTP client will wait for a response.
+     */
+    private $requestTimeout = 10;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnectTimeout(): float
+    {
+        return $this->connectTimeout;
+    }
+
+    /**
+     * Gets the numbers of seconds the HTTP client will wait for the response body to finish
+     * streaming before timing out.
+     *
+     * @return float
+     */
+    public function getReadTimeout(): float
+    {
+        return $this->readTimeout;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequestTimeout(): float
+    {
+        return $this->requestTimeout;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConnectTimeout(?float $timeout): void
+    {
+        $this->connectTimeout = $this->validateTimeoutValue($timeout);
+    }
+
+    /**
+     * Sets the numbers of seconds the HTTP client will wait for the response body to finish
+     * streaming before timing out.
+     *
+     * @param float $timeout
+     *
+     * @return void
+     */
+    public function setReadTimeout(float $timeout): void
+    {
+        $this->readTimeout = $this->validateTimeoutValue($timeout);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRequestTimeout(?float $timeout): void
+    {
+        $this->requestTimeout = $this->validateTimeoutValue($timeout);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            RequestOptions::CONNECT_TIMEOUT => $this->connectTimeout,
+            RequestOptions::READ_TIMEOUT => $this->readTimeout,
+            RequestOptions::TIMEOUT => $this->requestTimeout
+        ];
+    }
+
+    /**
+     * Ensures that the provided timeout value is valid.
+     *
+     * @param float|null $timeout
+     *
+     * @return float
+     */
+    private function validateTimeoutValue(?float $timeout): float
+    {
+        // Ensure a sane value, anything less than 0.0 we can assume disabled
+        if ($timeout === null || $timeout < 0.0) {
+            $timeout = 0.0;
+        }
+
+        return $timeout;
+    }
+}

--- a/src/HttpClient/ClientOptions.php
+++ b/src/HttpClient/ClientOptions.php
@@ -14,7 +14,7 @@ class ClientOptions implements ClientOptionsInterface
     private $connectTimeout = 5;
 
     /**
-     * @var int The number of seconds the HTTP client will wait for the response body to
+     * @var float The number of seconds the HTTP client will wait for the response body to
      *          stream before timing out.
      */
     private $readTimeout = 0;

--- a/src/HttpClient/ClientOptions.php
+++ b/src/HttpClient/ClientOptions.php
@@ -6,21 +6,38 @@ namespace EoneoPay\Externals\HttpClient;
 use EoneoPay\Externals\HttpClient\Interfaces\ClientOptionsInterface;
 use GuzzleHttp\RequestOptions;
 
+/**
+ * Options passed through to the underlying Guzzle client.
+ *
+ * The timeouts are in the following order in regards to the request lifecycle:
+ *     1) Connection Timeout: The number of seconds the client will wait to connect to the host.
+ *     2) Request Timeout: The number of seconds the client will wait for the first byte from the host.
+ *     3) Read Timeout: The number of seconds the client will wait for the response to stream from the host to client.
+ */
 class ClientOptions implements ClientOptionsInterface
 {
     /**
      * @var float The number of seconds the HTTP client will wait to connect.
+     *
+     * @see http://docs.guzzlephp.org/en/stable/request-options.html#connect-timeout
      */
-    private $connectTimeout = 5;
+    private $connectTimeout = 2;
 
     /**
      * @var float The number of seconds the HTTP client will wait for the response body to
      *          stream before timing out.
+     *
+     * Note: This timeout applies to individual read operations on a streamed body (being, the 'stream' option
+     * passed to Guzzle is set to 'true').
+     *
+     * @see http://docs.guzzlephp.org/en/stable/request-options.html#read-timeout
      */
-    private $readTimeout = 0;
+    private $readTimeout = 3;
 
     /**
      * @var float The number of seconds the HTTP client will wait for a response.
+     *
+     * @see http://docs.guzzlephp.org/en/stable/request-options.html#timeout
      */
     private $requestTimeout = 10;
 

--- a/src/HttpClient/Interfaces/ClientOptionsInterface.php
+++ b/src/HttpClient/Interfaces/ClientOptionsInterface.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Externals\HttpClient\Interfaces;
+
+interface ClientOptionsInterface
+{
+    /**
+     * Gets the numbers of seconds the HTTP client will wait to connect before timing out.
+     *
+     * @return float
+     */
+    public function getConnectTimeout(): float;
+
+    /**
+     * Gets the numbers of seconds the HTTP client will wait for the response body to finish
+     * streaming before timing out.
+     *
+     * @return float
+     */
+    public function getReadTimeout(): float;
+
+    /**
+     * Gets the numbers of seconds the HTTP client will wait for a response before timing out.
+     *
+     * @return float
+     */
+    public function getRequestTimeout(): float;
+
+    /**
+     * Sets the numbers of seconds the HTTP client will wait for to connect before timing out.
+     *
+     * @param float $timeout
+     *
+     * @return void
+     */
+    public function setConnectTimeout(float $timeout): void;
+
+    /**
+     * Sets the numbers of seconds the HTTP client will wait for the response body to finish
+     * streaming before timing out.
+     *
+     * @param float $timeout
+     *
+     * @return void
+     */
+    public function setReadTimeout(float $timeout): void;
+
+    /**
+     * Sets the numbers of seconds the HTTP client will wait for a response before timing out.
+     *
+     * @param float $timeout
+     *
+     * @return void
+     */
+    public function setRequestTimeout(float $timeout): void;
+
+    /**
+     * Returns the client options in an array that is compatible for use with Guzzle.
+     *
+     * @return mixed[]
+     */
+    public function toArray(): array;
+}

--- a/tests/HttpClient/ClientOptionsTest.php
+++ b/tests/HttpClient/ClientOptionsTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\Externals\HttpClient;
+
+use EoneoPay\Externals\HttpClient\ClientOptions;
+use GuzzleHttp\RequestOptions;
+use Tests\EoneoPay\Externals\TestCase;
+
+/**
+ * @covers \EoneoPay\Externals\HttpClient\ClientOptions
+ */
+class ClientOptionsTest extends TestCase
+{
+    /**
+     * Tests that the internal `parseTimeoutValue` method correctly
+     *
+     * @return void
+     */
+    public function testClientOptionsFixedInvalidNegativeValue(): void
+    {
+        $options = new ClientOptions();
+
+        $options->setConnectTimeout(-123.45);
+
+        self::assertSame(0.0, $options->getConnectTimeout());
+    }
+
+    /**
+     * Tests that the `getConnectTimeout` method returns the value provided to the `setConnectTimeout` method.
+     *
+     * @return void
+     */
+    public function testConnectTimeout(): void
+    {
+        $options = new ClientOptions();
+        $expected = 2.25;
+
+        $options->setConnectTimeout(2.25);
+
+        self::assertSame($expected, $options->getConnectTimeout());
+    }
+
+    /**
+     * Tests that the `getReadTimeout` method returns the value provided to the `setReadTimeout` method.
+     *
+     * @return void
+     */
+    public function testReadTimeout(): void
+    {
+        $options = new ClientOptions();
+        $expected = 42.0;
+
+        $options->setReadTimeout(42.0);
+
+        self::assertSame($expected, $options->getReadTimeout());
+    }
+
+    /**
+     * Tests that the `getRequestTimeout` method returns the value provided to the `setRequestTimeout` method.
+     *
+     * @return void
+     */
+    public function testRequestTimeout(): void
+    {
+        $options = new ClientOptions();
+        $expected = 123.0;
+
+        $options->setRequestTimeout(123.0);
+
+        self::assertSame($expected, $options->getRequestTimeout());
+    }
+
+    /**
+     * Tests that the `toArray` method returns the correctly formatted array.
+     *
+     * @return void
+     */
+    public function testToArray(): void
+    {
+        $options = new ClientOptions();
+        $options->setConnectTimeout(1.2);
+        $options->setReadTimeout(6.0);
+        $options->setRequestTimeout(1.3);
+        $expected = [
+            RequestOptions::READ_TIMEOUT => 6.0,
+            RequestOptions::CONNECT_TIMEOUT => 1.2,
+            RequestOptions::TIMEOUT => 1.3
+        ];
+
+        $result = $options->toArray();
+
+        self::assertEquals($expected, $result);
+    }
+}

--- a/tests/HttpClient/ClientTest.php
+++ b/tests/HttpClient/ClientTest.php
@@ -12,10 +12,8 @@ use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\RequestOptions;
 use Tests\EoneoPay\Externals\TestCase;
 
 /**
@@ -151,7 +149,6 @@ class ClientTest extends TestCase
      * Create client instance
      *
      * @param \GuzzleHttp\Handler\MockHandler $handler Guzzle mock handler
-     *
      * @param \EoneoPay\Externals\HttpClient\Interfaces\ClientOptionsInterface|null $clientOptions
      *
      * @return \EoneoPay\Externals\HttpClient\Client

--- a/tests/HttpClient/ClientTest.php
+++ b/tests/HttpClient/ClientTest.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 namespace Tests\EoneoPay\Externals\HttpClient;
 
 use EoneoPay\Externals\HttpClient\Client;
+use EoneoPay\Externals\HttpClient\ClientOptions;
 use EoneoPay\Externals\HttpClient\ExceptionHandler;
 use EoneoPay\Externals\HttpClient\Exceptions\InvalidApiResponseException;
+use EoneoPay\Externals\HttpClient\Interfaces\ClientOptionsInterface;
 use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\RequestOptions;
 use Tests\EoneoPay\Externals\TestCase;
 
 /**
@@ -118,7 +122,7 @@ class ClientTest extends TestCase
         $result = $client->sendRequest(new Request('post', '/'));
 
         self::assertSame(200, $result->getStatusCode());
-        self::assertSame('ok', $result->getBody()->__toString());
+        self::assertSame('ok', (string)$result->getBody());
     }
 
     /**
@@ -148,14 +152,19 @@ class ClientTest extends TestCase
      *
      * @param \GuzzleHttp\Handler\MockHandler $handler Guzzle mock handler
      *
+     * @param \EoneoPay\Externals\HttpClient\Interfaces\ClientOptionsInterface|null $clientOptions
+     *
      * @return \EoneoPay\Externals\HttpClient\Client
      */
-    private function createInstance(MockHandler $handler): Client
-    {
+    private function createInstance(
+        MockHandler $handler,
+        ?ClientOptionsInterface $clientOptions = null
+    ): Client {
         // Create guzzle with mock response
         return new Client(
             new Guzzle(['handler' => $handler]),
-            new ExceptionHandler()
+            new ExceptionHandler(),
+            $clientOptions ?? new ClientOptions()
         );
     }
 }


### PR DESCRIPTION
This PR updates the `Client` class in `externals`, providing flexible control of Guzzle's connection, read, and response timeouts through a `ClientOptions` class that it passed in to the constructor of the `Client` class.

This added functionality does not cause any breaking changes, and the defaults are 5 seconds for connect timeout, 10 seconds for response timeout, infinite read timeout.