### PR TITLE
PYMT-937 Extract base EntityInterface

### DIFF
--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -101,22 +101,6 @@ abstract class Entity implements MagicEntityInterface
     }
 
     /**
-     * Returns all properties on the entity.
-     *
-     * @return string[]
-     */
-    public function getProperties(): array
-    {
-        $properties = \array_keys(\get_object_vars($this));
-
-        return \array_filter($properties, static function ($property): bool {
-            // Skip all properties that have __ at the start, they are reserved properties
-            // and should not be processed.
-            return \strncmp($property, '__', 2) !== 0;
-        });
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function jsonSerialize(): array
@@ -232,6 +216,22 @@ abstract class Entity implements MagicEntityInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Returns all properties on the entity.
+     *
+     * @return string[]
+     */
+    protected function getObjectProperties(): array
+    {
+        $properties = \array_keys(\get_object_vars($this));
+
+        return \array_filter($properties, static function ($property): bool {
+            // Skip all properties that have __ at the start, they are reserved properties
+            // and should not be processed.
+            return \strncmp($property, '__', 2) !== 0;
+        });
     }
 
     /**
@@ -486,7 +486,9 @@ abstract class Entity implements MagicEntityInterface
         // All properties will be camel case within the object
         $property = \lcfirst($property);
 
-        return \property_exists($this, $property) ? $property : (new Arr())->search($this->getProperties(), $property);
+        return \property_exists($this, $property)
+            ? $property :
+            (new Arr())->search($this->getObjectProperties(), $property);
     }
 
     /**

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -6,6 +6,7 @@ namespace EoneoPay\Externals\ORM;
 use EoneoPay\Externals\ORM\Exceptions\InvalidMethodCallException;
 use EoneoPay\Externals\ORM\Exceptions\InvalidRelationshipException;
 use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
+use EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface;
 use EoneoPay\Utils\Arr;
 use EoneoPay\Utils\Exceptions\InvalidXmlTagException;
 use EoneoPay\Utils\XmlConverter;
@@ -13,7 +14,7 @@ use EoneoPay\Utils\XmlConverter;
 /**
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Complexity required to enable smaller entities in application
  */
-abstract class Entity implements EntityInterface
+abstract class Entity implements MagicEntityInterface
 {
     /**
      * Create a new entity
@@ -100,7 +101,9 @@ abstract class Entity implements EntityInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Returns all properties on the entity.
+     *
+     * @return string[]
      */
     public function getProperties(): array
     {

--- a/src/ORM/Interfaces/EntityInterface.php
+++ b/src/ORM/Interfaces/EntityInterface.php
@@ -8,44 +8,9 @@ use EoneoPay\Utils\Interfaces\SerializableInterface;
 interface EntityInterface extends SerializableInterface
 {
     /**
-     * Allow getX() and setX($value) to get and set column values
-     *
-     * This method searches case insensitive
-     *
-     * @param string $method The method being called
-     * @param mixed[] $parameters Parameters passed to the method
-     *
-     * @return mixed Value or null on getX(), self on setX(value)
-     */
-    public function __call(string $method, array $parameters);
-
-    /**
-     * Fill an entity from an array
-     *
-     * @param mixed[] $data The array to fill the entity from
-     *
-     * @return void
-     */
-    public function fill(array $data): void;
-
-    /**
-     * Get a list of attributes or keys which are able to be filled, by default all fields can be set
-     *
-     * @return string[]
-     */
-    public function getFillableProperties(): array;
-
-    /**
      * Get entity id.
      *
      * @return null|string|int
      */
     public function getId();
-
-    /**
-     * Get all properties for this entity
-     *
-     * @return string[]
-     */
-    public function getProperties(): array;
 }

--- a/src/ORM/Interfaces/EntityInterface.php
+++ b/src/ORM/Interfaces/EntityInterface.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace EoneoPay\Externals\ORM\Interfaces;
 
-use EoneoPay\Utils\Interfaces\SerializableInterface;
-
-interface EntityInterface extends SerializableInterface
+interface EntityInterface
 {
     /**
      * Get entity id.

--- a/src/ORM/Interfaces/MagicEntityInterface.php
+++ b/src/ORM/Interfaces/MagicEntityInterface.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace EoneoPay\Externals\ORM\Interfaces;
 
-interface MagicEntityInterface extends EntityInterface
+use EoneoPay\Utils\Interfaces\SerializableInterface;
+
+interface MagicEntityInterface extends EntityInterface, SerializableInterface
 {
     /**
      * Allow getX() and setX($value) to get and set column values

--- a/src/ORM/Interfaces/MagicEntityInterface.php
+++ b/src/ORM/Interfaces/MagicEntityInterface.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Externals\ORM\Interfaces;
+
+interface MagicEntityInterface extends EntityInterface
+{
+    /**
+     * Allow getX() and setX($value) to get and set column values
+     *
+     * This method searches case insensitive
+     *
+     * @param string $method The method being called
+     * @param mixed[] $parameters Parameters passed to the method
+     *
+     * @return mixed Value or null on getX(), self on setX(value)
+     */
+    public function __call(string $method, array $parameters);
+
+    /**
+     * Fill an entity from an array
+     *
+     * @param mixed[] $data The array to fill the entity from
+     *
+     * @return void
+     */
+    public function fill(array $data): void;
+
+    /**
+     * Get a list of attributes or keys which are able to be filled, by default all fields can be set
+     *
+     * @return string[]
+     */
+    public function getFillableProperties(): array;
+}

--- a/src/ORM/Interfaces/ValidatableInterface.php
+++ b/src/ORM/Interfaces/ValidatableInterface.php
@@ -6,11 +6,11 @@ namespace EoneoPay\Externals\ORM\Interfaces;
 interface ValidatableInterface extends EntityInterface
 {
     /**
-     * Get all properties for this entity
+     * Get all validatable properties for this entity
      *
      * @return string[]
      */
-    public function getProperties(): array;
+    public function getValidatableProperties(): array;
 
     /**
      * Get validation rules.

--- a/src/ORM/Interfaces/ValidatableInterface.php
+++ b/src/ORM/Interfaces/ValidatableInterface.php
@@ -6,6 +6,13 @@ namespace EoneoPay\Externals\ORM\Interfaces;
 interface ValidatableInterface extends EntityInterface
 {
     /**
+     * Get all properties for this entity
+     *
+     * @return string[]
+     */
+    public function getProperties(): array;
+
+    /**
      * Get validation rules.
      *
      * @return mixed[]

--- a/src/ORM/Subscribers/LoggableEventSubscriber.php
+++ b/src/ORM/Subscribers/LoggableEventSubscriber.php
@@ -5,7 +5,7 @@ namespace EoneoPay\Externals\ORM\Subscribers;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Mapping\Column;
-use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
+use EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface;
 use EoneoPay\Utils\AnnotationReader;
 use Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry;
 use Gedmo\Loggable\LoggableListener as BaseLoggableListener;
@@ -58,7 +58,7 @@ final class LoggableEventSubscriber extends BaseLoggableListener
         $config = parent::getConfiguration($objectManager, $class);
         $entity = new $class();
 
-        if (($entity instanceof EntityInterface) === false || \count($this->getEntityFillable($entity)) === 0) {
+        if (($entity instanceof MagicEntityInterface) === false || \count($this->getEntityFillable($entity)) === 0) {
             return $config;
         }
 
@@ -71,13 +71,13 @@ final class LoggableEventSubscriber extends BaseLoggableListener
     /**
      * Get fillable properties for given entity.
      *
-     * @param \EoneoPay\Externals\ORM\Interfaces\EntityInterface $entity
+     * @param \EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface $entity
      *
      * @return string[]
      *
      * @throws \EoneoPay\Utils\Exceptions\AnnotationCacheException If opcache extension isn't loaded
      */
-    private function getEntityFillable(EntityInterface $entity): array
+    private function getEntityFillable(MagicEntityInterface $entity): array
     {
         if (\in_array('*', $entity->getFillableProperties(), true) === false) {
             return $entity->getFillableProperties();

--- a/src/ORM/Subscribers/ValidateEventSubscriber.php
+++ b/src/ORM/Subscribers/ValidateEventSubscriber.php
@@ -6,7 +6,6 @@ namespace EoneoPay\Externals\ORM\Subscribers;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
-use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
 use EoneoPay\Externals\ORM\Interfaces\ValidatableInterface;
 use EoneoPay\Externals\Translator\Interfaces\TranslatorInterface;
 use EoneoPay\Externals\Validator\Interfaces\ValidatorInterface;
@@ -116,11 +115,11 @@ final class ValidateEventSubscriber implements EventSubscriber
      * Get entity contents via reflection, this is used so there's no reliance
      * on entity methods such as toArray().
      *
-     * @param \EoneoPay\Externals\ORM\Interfaces\EntityInterface $entity
+     * @param \EoneoPay\Externals\ORM\Interfaces\ValidatableInterface $entity
      *
      * @return mixed[]
      */
-    private function getEntityContents(EntityInterface $entity): array
+    private function getEntityContents(ValidatableInterface $entity): array
     {
         $contents = [];
         foreach ($entity->getProperties() as $property) {

--- a/src/ORM/Subscribers/ValidateEventSubscriber.php
+++ b/src/ORM/Subscribers/ValidateEventSubscriber.php
@@ -122,7 +122,7 @@ final class ValidateEventSubscriber implements EventSubscriber
     private function getEntityContents(ValidatableInterface $entity): array
     {
         $contents = [];
-        foreach ($entity->getProperties() as $property) {
+        foreach ($entity->getValidatableProperties() as $property) {
             $getter = [$entity, \sprintf('get%s', \ucfirst($property))];
 
             // If getter isn't available, continue - this is only here for safety since base entity provides __call

--- a/tests/ORM/EntityTest.php
+++ b/tests/ORM/EntityTest.php
@@ -265,16 +265,21 @@ class EntityTest extends ORMTestCase
     }
 
     /**
-     * Tests that getProperties ignores double underscore properties set by Doctrine
-     * proxy definitions.
+     * Tests that getObjectProperties does not allow operations on __ prefixed properties
+     * which are considered internal implementation details by php.
      *
      * @return void
      */
-    public function testGetPropertiesIgnoresUnderscores(): void
+    public function testGetObjectPropertiesIgnoresUnderscores(): void
     {
         $entity = new EntityProxyStub();
+        $entity->__initializer__ = true;
+        $entity->fill([
+            // Due to quirks of the Array search method, the trailing __ is omitted
+            '__initializer' => false
+        ]);
 
-        self::assertNotContains('__initializer', $entity->getProperties());
+        static::assertTrue($entity->__initializer__);
     }
 
     /**

--- a/tests/Stubs/ORM/Entities/ValidatableStub.php
+++ b/tests/Stubs/ORM/Entities/ValidatableStub.php
@@ -26,6 +26,14 @@ class ValidatableStub extends EntityStub implements ValidatableInterface
     /**
      * {@inheritdoc}
      */
+    public function getValidatableProperties(): array
+    {
+        return $this->getObjectProperties();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getValidationFailedException(): string
     {
         return EntityValidationFailedExceptionStub::class;

--- a/tests/Stubs/ORM/Entities/ValidationRulesStub.php
+++ b/tests/Stubs/ORM/Entities/ValidationRulesStub.php
@@ -40,6 +40,14 @@ class ValidationRulesStub extends Entity implements ValidatableInterface
     /**
      * {@inheritdoc}
      */
+    public function getValidatableProperties(): array
+    {
+        return $this->getObjectProperties();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getValidationFailedException(): string
     {
         return EntityValidationFailedExceptionStub::class;


### PR DESCRIPTION
First PR on the journey to remove Serialisable from subscription entities.

- Extracts most magic from the EntityInterface into the MagicEntityInterface or the ValidatableInterface

Testing this against projects:
- [x] Payments
- [ ] Framework
- [x] Skeleton
- [x] Subscriptions
- [x] Notifications