### PR TITLE
PYMT-937 Extract Simple functionality out into SimpleEntity

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,9 +7,6 @@ parameters:
             message: '#Call to an undefined method Illuminate\\Contracts\\Filesystem\\Filesystem::path\(\).#'
             path: src/Bridge/Laravel/Filesystem.php
         -
-            message: '#Class Tests\\EoneoPay\\Externals\\Stubs\\ORM\\Entities\\InvalidClass not found.#'
-            path: tests/Stubs/ORM/Entities/EntityStub.php
-        -
             message: '#Constant XDEBUG_[A-Z_]+ not found.#'
             path: tests/bootstrap.php
         -
@@ -25,8 +22,15 @@ parameters:
             message: '#Variable property access on \$this\(EoneoPay\\Externals\\ORM\\Entity\).#'
             path: src/ORM/Entity.php
         -
+            message: '#Variable property access on \$this\(EoneoPay\\Externals\\ORM\\SimpleEntity\).#'
+            path: src/ORM/SimpleEntity.php
+        -
             message: '#Variable property access on \$this\(Tests\\EoneoPay\\Externals\\Stubs\\ORM\\Entities\\EntityStub|TransformerStub\).#'
             path: src/ORM/Traits/HasTransformers.php
         -
             message: '#Parameter \#3 \$previous of class EoneoPay\\Externals\\HttpClient\\Exceptions\\InvalidApiResponseException constructor expects Throwable\|null, GuzzleHttp\\Exception\\GuzzleException given\.#'
             path: src/HttpClient/Client.php
+        -
+            message: '#Call to protected method setWithSetter\(\) of class Tests\\EoneoPay\\Externals\\Stubs\\ORM\\Entities\\SimpleEntityStub\.#'
+            path: tests/ORM/SimpleEntityTest.php
+

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -56,7 +56,7 @@ abstract class Entity extends SimpleEntity implements MagicEntityInterface
             $resolved = $this->resolveProperty($matches[1]);
 
             // Run transformer if applicable
-            $method = \sprintf('transform%s', \ucfirst($resolved));
+            $method = \sprintf('transform%s', \ucfirst($resolved ?? ''));
             $callable = [$this, $method];
             if (\method_exists($this, $method) === true && \is_callable($callable) === true) {
                 $callable();

--- a/src/ORM/SimpleEntity.php
+++ b/src/ORM/SimpleEntity.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\Externals\ORM;
+
+use EoneoPay\Externals\ORM\Exceptions\InvalidMethodCallException;
+use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
+use EoneoPay\Utils\Arr;
+
+/**
+ * This abstract entity class is designed as a stop-gap solution to removal
+ * of the base entity entirely.
+ */
+abstract class SimpleEntity implements EntityInterface
+{
+    /**
+     * Allow getX() and setX($value) to get and set column values
+     *
+     * This method searches case insensitive
+     *
+     * @param string $method The method being called
+     * @param mixed[] $parameters Parameters passed to the method
+     *
+     * @return mixed Value or null on getX(), self on setX(value)
+     */
+    public function __call(string $method, array $parameters)
+    {
+        // Set available types
+        $types = ['get', 'has', 'is', 'set'];
+
+        // Break calling method into type (get, has, is, set) and attribute
+        \preg_match('/^(' . \implode('|', $types) . ')([a-zA-Z][\w]+)$/i', $method, $matches);
+
+        $type = \mb_strtolower($matches[1] ?? '');
+        $property = $this->resolveProperty($matches[2] ?? '');
+
+        // The property being accessed must exist and the type must be valid if one of these things
+        // aren't true throw an exception
+        if ($type === '' || $property === null) {
+            throw new InvalidMethodCallException(
+                \sprintf('Call to undefined method %s::%s()', \get_class($this), $method)
+            );
+        }
+
+        // Perform action - code coverage disabled due to phpdbg not seeing case statements
+        switch ($type) {
+            case 'get': // @codeCoverageIgnore
+            case 'has': // @codeCoverageIgnore
+            case 'is': // @codeCoverageIgnore
+                return $this->callGettableMethod($type, $property);
+
+            case 'set': // @codeCoverageIgnore
+                // Return original instance for fluency
+                $this->set($property, \reset($parameters));
+                break;
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->get($this->getIdProperty());
+    }
+
+    /**
+     * Get the id property for this entity
+     *
+     * @return string
+     */
+    abstract protected function getIdProperty(): string;
+
+    /**
+     * Returns all properties on the entity.
+     *
+     * @return string[]
+     */
+    protected function getObjectProperties(): array
+    {
+        $properties = \array_keys(\get_object_vars($this));
+
+        return \array_filter($properties, static function ($property): bool {
+            // Skip all properties that have __ at the start, they are reserved properties
+            // and should not be processed.
+            return \strncmp($property, '__', 2) !== 0;
+        });
+    }
+
+    /**
+     * Get property value via getter
+     *
+     * @param string $property The property to get
+     *
+     * @return mixed
+     */
+    protected function getValue(string $property)
+    {
+        $getter = [$this, \sprintf('get%s', \ucfirst($property))];
+
+        return \is_callable($getter) === true ? $getter() : null;
+    }
+
+    /**
+     * Get instance_of rule string for given class.
+     *
+     * @param string $class
+     *
+     * @return string
+     */
+    protected function instanceOfRuleAsString(string $class): string
+    {
+        return \sprintf('instance_of:%s', $class);
+    }
+
+    /**
+     * Get unique rule string for given target property and optional where clauses.
+     *
+     * @param string $target The target entity
+     * @param mixed[]|null $wheres Additional/optional where clauses
+     *
+     * @return string
+     */
+    protected function uniqueRuleAsString(string $target, ?array $wheres = null): string
+    {
+        $additional = '';
+        foreach ($wheres ?? [] as $column => $value) {
+            $additional .= \sprintf(',%s,%s', $column, $value);
+        }
+
+        $rule = \sprintf(
+            'unique:%s,%s,%s,%s%s',
+            \get_class($this),
+            $target,
+            $this->getValue($this->getIdProperty()),
+            $this->getIdProperty(),
+            $additional
+        );
+
+        return $rule;
+    }
+
+    /**
+     * Perform a gettable call on an entity
+     *
+     * @param string $method The method being called
+     * @param string $property The property the method is being called on
+     *
+     * @return mixed The property value, or null/false if method isn't callable
+     */
+    private function callGettableMethod(string $method, string $property)
+    {
+        // Determine callable method
+        $callable = [$this, $method === 'is' ? 'get' : $method];
+
+        // Only call method if it's callable
+        if (\is_callable($callable) === true) {
+            return ($method === 'is') ? (bool)$callable($property) : $callable($property);
+        }
+
+        // If call didn't happen, return null/false depending on type - this is unlikely since the
+        // property is verified via the __call method and has() and get() exist in this class
+        return $method === 'get' ? null : false; // @codeCoverageIgnore
+    }
+
+    /**
+     * Get a value from a property
+     *
+     * @param string $property The property to get the value of
+     *
+     * @return mixed The property value
+     */
+    private function get(string $property)
+    {
+        $resolved = $this->resolveProperty($property);
+
+        return $resolved !== null ? $this->{$resolved} : null;
+    }
+
+    /**
+     * Determine if a property exists on an entity
+     *
+     * @param string $property The property to test
+     *
+     * @return bool
+     */
+    private function has(string $property): bool
+    {
+        return $this->resolveProperty($property) !== null;
+    }
+
+    /**
+     * Resolve property without case sensitivity or special characters, resolves property such as
+     * addressStreet to addressstreet, address_street or ADDRESSSTREET
+     *
+     * @param string $property The property to resolve
+     *
+     * @return string|null
+     */
+    private function resolveProperty(string $property): ?string
+    {
+        // All properties will be camel case within the object
+        $property = \lcfirst($property);
+
+        return \property_exists($this, $property)
+            ? $property :
+            (new Arr())->search($this->getObjectProperties(), $property);
+    }
+
+    /**
+     * Set the value for a property
+     *
+     * @param string $property The property to set
+     * @param mixed $value The value to set
+     *
+     * @return mixed The entity the set method was called on
+     */
+    private function set(string $property, $value)
+    {
+        $resolved = (string)$this->resolveProperty($property);
+
+        // Set property value, prefer setter over direct set
+        $setter = \sprintf('set%s', \ucfirst($resolved));
+        $callable = [$this, $setter];
+        \method_exists($this, $setter) === true && \is_callable($callable) === true ?
+            $callable($value) :
+            $this->{$resolved} = $value;
+
+        return $this;
+    }
+}

--- a/src/ORM/SimpleEntity.php
+++ b/src/ORM/SimpleEntity.php
@@ -182,9 +182,13 @@ abstract class SimpleEntity implements EntityInterface
     /**
      * Determine if a property exists on an entity
      *
+     * @noinspection PhpUnusedPrivateMethodInspection This method is used by __call
+     *
      * @param string $property The property to test
      *
      * @return bool
+     *
+     * @SuppressWarnings(PHPMD.UnusedPrivateMethod) This method is used by __call
      */
     private function has(string $property): bool
     {

--- a/tests/ORM/EntityTest.php
+++ b/tests/ORM/EntityTest.php
@@ -185,10 +185,10 @@ class EntityTest extends ORMTestCase
      */
     public function testAssociateWithWrongAssociationException(): void
     {
-        $this->expectException(InvalidRelationshipException::class);
-
         $parent = new ParentStub();
         $child = new ChildStub(['annotation_name' => 'string']);
+
+        $this->expectException(InvalidRelationshipException::class);
 
         $child->setInvalidParent($parent);
     }
@@ -248,23 +248,6 @@ class EntityTest extends ORMTestCase
     }
 
     /**
-     * Test entity has a generic getId method which return id value based on Id doctrine annotation.
-     *
-     * @return void
-     */
-    public function testGetIdReturnsRightValueBasedOnIdAnnotation(): void
-    {
-        $entity = new EntityStub();
-        $entityId = 'my-entity-id';
-
-        self::assertNull($entity->getId());
-
-        $entity->setEntityId($entityId);
-
-        self::assertSame($entityId, $entity->getId());
-    }
-
-    /**
      * Tests that getObjectProperties does not allow operations on __ prefixed properties
      * which are considered internal implementation details by php.
      *
@@ -302,24 +285,6 @@ class EntityTest extends ORMTestCase
     }
 
     /**
-     * Test instanceOfRuleAsString build correctly the string representation of the validation rule.
-     *
-     * @return void
-     */
-    public function testInstanceOfRuleAsStringMethod(): void
-    {
-        self::assertSame(
-            'instance_of:stdClass',
-            (new EntityStub())->getInstanceOfRuleForTest(\stdClass::class)
-        );
-
-        self::assertSame(
-            'instance_of:Tests\EoneoPay\Externals\Stubs\ORM\Entities\EntityStub',
-            (new EntityStub())->getInstanceOfRuleForTest(EntityStub::class)
-        );
-    }
-
-    /**
      * Test entity can be json serialized
      *
      * @return void
@@ -330,92 +295,6 @@ class EntityTest extends ORMTestCase
     {
         $entity = new EntityStub(self::$data);
         self::assertSame(\json_encode($this->getEntityContents($entity)), \json_encode($entity));
-    }
-
-    /**
-     * Test __call allows setting and getting of data
-     *
-     * @return void
-     */
-    public function testMagicCallCanGetAndSetAccessesEntityProperties(): void
-    {
-        $entity = new EntityStub();
-        self::assertEmpty(\array_filter($this->getEntityContents($entity)));
-
-        // Test check entity has properties
-        self::assertTrue($entity->hasString());
-
-        // Test string is not set
-        self::assertFalse($entity->isString());
-
-        // Test setting email returns entity instance
-        self::assertSame($entity, $entity->setString(self::$data['string']));
-
-        // Test string is set
-        self::assertTrue($entity->isString());
-
-        // Attempt to grab value
-        self::assertSame(self::$data['string'], $entity->getString());
-    }
-
-    /**
-     * Test __call with invalid accessor throws exception
-     *
-     * @return void
-     */
-    public function testMagicCallThrowsExceptionIfAccessorInvalid(): void
-    {
-        $entity = new EntityStub();
-
-        $this->expectException(InvalidMethodCallException::class);
-        $entity->whenString();
-    }
-
-    /**
-     * Test __call with invalid property throws exception
-     *
-     * @return void
-     */
-    public function testMagicCallThrowsExceptionIfPropertyInvalid(): void
-    {
-        $entity = new EntityStub();
-
-        $this->expectException(InvalidMethodCallException::class);
-        $entity->getInvalid();
-    }
-
-    /**
-     * Test the property annotations method on the entity stub contains invalid items
-     *
-     * @return void
-     */
-    public function testPropertyAnnotationsContainsInvalidClassAndAttribute(): void
-    {
-        $entity = new EntityStub();
-
-        $expected = [
-            'Tests\EoneoPay\Externals\Stubs\ORM\Entities\InvalidClass' => 'name', // This class is invalid
-            Column::class => 'name',
-            Id::class => 'invalid' // This attribute is invalid
-        ];
-
-        self::assertSame($expected, $entity->getPropertyAnnotations());
-    }
-
-    /**
-     * Test __call finds properties via annotations
-     *
-     * @return void
-     *
-     * @depends testPropertyAnnotationsContainsInvalidClassAndAttribute
-     */
-    public function testPropertyAnnotationsSetAndGetViaMagicMethods(): void
-    {
-        $entity = new EntityStub();
-
-        self::assertNull($entity->getString());
-        self::assertSame($entity, $entity->setString('test'));
-        self::assertSame('test', $entity->getString());
     }
 
     /**
@@ -474,18 +353,5 @@ class EntityTest extends ORMTestCase
     public function testToXmlWithInvalidRootNodeReturnsNull(): void
     {
         self::assertNull((new EntityStub())->toXml('@invalid'));
-    }
-
-    /**
-     * Test uniqueRuleAsString build correctly the string representation of the validation rule.
-     *
-     * @return void
-     */
-    public function testUniqueRuleAsStringMethod(): void
-    {
-        self::assertSame(
-            'unique:Tests\EoneoPay\Externals\Stubs\ORM\Entities\EntityStub,email,,entityId,where1,value1',
-            (new EntityStub())->getEmailUniqueRuleForTest(['where1' => 'value1'])
-        );
     }
 }

--- a/tests/ORM/EntityTest.php
+++ b/tests/ORM/EntityTest.php
@@ -3,9 +3,6 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\Externals\ORM;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Id;
-use EoneoPay\Externals\ORM\Exceptions\InvalidMethodCallException;
 use EoneoPay\Externals\ORM\Exceptions\InvalidRelationshipException;
 use Tests\EoneoPay\Externals\Stubs\ORM\Entities\ChildStub;
 use Tests\EoneoPay\Externals\Stubs\ORM\Entities\EntityProxyStub;

--- a/tests/ORM/SimpleEntityTest.php
+++ b/tests/ORM/SimpleEntityTest.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\Externals\ORM;
+
+use EoneoPay\Externals\ORM\Exceptions\InvalidMethodCallException;
+use Tests\EoneoPay\Externals\Stubs\ORM\Entities\SimpleEntityStub;
+use Tests\EoneoPay\Externals\TestCases\ORMTestCase;
+
+/**
+ * @covers \EoneoPay\Externals\ORM\SimpleEntity
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Coupling is required to fully test entity functionality
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods) All test cases must be public
+ */
+class SimpleEntityTest extends ORMTestCase
+{
+    /**
+     * Data to populate the entity with for testing
+     *
+     * @var mixed[]
+     */
+    private static $data = [
+        'entityId' => null,
+        'integer' => 1,
+        'string' => 'test@test.com',
+        'deletedAt' => null
+    ];
+
+    /**
+     * Test entity has a generic getId method which return id value based on Id doctrine annotation.
+     *
+     * @return void
+     */
+    public function testGetIdReturnsRightValueBasedOnIdAnnotation(): void
+    {
+        $entity = new SimpleEntityStub();
+        $entityId = 'my-entity-id';
+
+        self::assertNull($entity->getId());
+
+        $entity->setEntityId($entityId);
+
+        self::assertSame($entityId, $entity->getId());
+    }
+
+    /**
+     * Test instanceOfRuleAsString build correctly the string representation of the validation rule.
+     *
+     * @return void
+     */
+    public function testInstanceOfRuleAsStringMethod(): void
+    {
+        self::assertSame(
+            'instance_of:stdClass',
+            (new SimpleEntityStub())->getInstanceOfRuleForTest(\stdClass::class)
+        );
+
+        self::assertSame(
+            'instance_of:Tests\EoneoPay\Externals\Stubs\ORM\Entities\SimpleEntityStub',
+            (new SimpleEntityStub())->getInstanceOfRuleForTest(SimpleEntityStub::class)
+        );
+    }
+
+    /**
+     * Test __call allows setting and getting of data
+     *
+     * @return void
+     */
+    public function testMagicCallCanGetAndSetAccessesEntityProperties(): void
+    {
+        $entity = new SimpleEntityStub();
+        self::assertEmpty(\array_filter($this->getEntityContents($entity)));
+
+        // Test check entity has properties
+        self::assertTrue($entity->hasString());
+
+        // Test string is not set
+        self::assertFalse($entity->isString());
+
+        // Test setting email returns entity instance
+        self::assertSame($entity, $entity->setString(self::$data['string']));
+
+        // Test string is set
+        self::assertTrue($entity->isString());
+
+        // Attempt to grab value
+        self::assertSame(self::$data['string'], $entity->getString());
+    }
+
+    /**
+     * Tests an entity property that has a real setter.
+     *
+     * @return void
+     */
+    public function testSetterWithDefinedSetter(): void
+    {
+        $entity = new SimpleEntityStub();
+        $entity->setWithSetter('test');
+
+        static::assertSame('test', $entity->getWithSetter());
+    }
+
+    /**
+     * Test __call with invalid accessor throws exception
+     *
+     * @return void
+     */
+    public function testMagicCallThrowsExceptionIfAccessorInvalid(): void
+    {
+        $entity = new SimpleEntityStub();
+
+        $this->expectException(InvalidMethodCallException::class);
+        $entity->whenString();
+    }
+
+    /**
+     * Test __call with invalid property throws exception
+     *
+     * @return void
+     */
+    public function testMagicCallThrowsExceptionIfPropertyInvalid(): void
+    {
+        $entity = new SimpleEntityStub();
+
+        $this->expectException(InvalidMethodCallException::class);
+        $entity->getInvalid();
+    }
+
+    /**
+     * Test uniqueRuleAsString build correctly the string representation of the validation rule.
+     *
+     * @return void
+     */
+    public function testUniqueRuleAsStringMethod(): void
+    {
+        self::assertSame(
+            'unique:Tests\EoneoPay\Externals\Stubs\ORM\Entities\SimpleEntityStub,email,,entityId,where1,value1',
+            (new SimpleEntityStub())->getEmailUniqueRuleForTest(['where1' => 'value1'])
+        );
+    }
+}

--- a/tests/Stubs/ORM/Entities/ChildStub.php
+++ b/tests/Stubs/ORM/Entities/ChildStub.php
@@ -53,22 +53,6 @@ class ChildStub extends EntityStub
     }
 
     /**
-     * Return an array of annotation/attribute pairs to search for properties in
-     *
-     * Note: Changing this array will cause the test testPropertyAnnotationsContainsInvalidClassAndAttribute() to fail
-     *
-     * @return string[]
-     *
-     * @see \Tests\EoneoPay\Externals\ORM\EntityTest::testPropertyAnnotationsContainsInvalidClassAndAttribute
-     */
-    public function getPropertyAnnotations(): array
-    {
-        parent::getPropertyAnnotations();
-
-        return [];
-    }
-
-    /**
      * Set parent with invalid relation.
      *
      * @param \Tests\EoneoPay\Externals\Stubs\ORM\Entities\ParentStub $parent

--- a/tests/Stubs/ORM/Entities/SimpleEntityStub.php
+++ b/tests/Stubs/ORM/Entities/SimpleEntityStub.php
@@ -12,6 +12,7 @@ use LaravelDoctrine\Extensions\SoftDeletes\SoftDeletes;
  * @method int|null getInteger()
  * @method string|null getEntityId()
  * @method string|null getString()
+ * @method string|null getWithSetter()
  * @method bool hasString()
  * @method bool isString()
  * @method self setInteger(int $integer)

--- a/tests/Stubs/ORM/Entities/SimpleEntityStub.php
+++ b/tests/Stubs/ORM/Entities/SimpleEntityStub.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 namespace Tests\EoneoPay\Externals\Stubs\ORM\Entities;
 
 use Doctrine\ORM\Mapping as ORM;
-use EoneoPay\Externals\ORM\Entity;
-use EoneoPay\Externals\ORM\Traits\HasTransformers;
+use EoneoPay\Externals\ORM\SimpleEntity;
 use Gedmo\Mapping\Annotation as Gedmo;
 use LaravelDoctrine\Extensions\SoftDeletes\SoftDeletes;
 
@@ -29,9 +28,8 @@ use LaravelDoctrine\Extensions\SoftDeletes\SoftDeletes;
  *
  * @Gedmo\SoftDeleteable()
  */
-class EntityStub extends Entity
+class SimpleEntityStub extends SimpleEntity
 {
-    use HasTransformers;
     use SoftDeletes;
 
     /**
@@ -64,6 +62,13 @@ class EntityStub extends Entity
     protected $string;
 
     /**
+     * Property that has a setter.
+     *
+     * @var string
+     */
+    protected $withSetter;
+
+    /**
      * Function exclusively for test purposes to test uniqueRuleAsString.
      *
      * @param string[]|null $wheres
@@ -88,30 +93,22 @@ class EntityStub extends Entity
     }
 
     /**
-     * Get the contents of the entity as an array
-     *
-     * @return mixed[]
-     */
-    public function toArray(): array
-    {
-        return \get_object_vars($this);
-    }
-
-    /**
-     * Make sure that string is a string.
-     *
-     * @return void
-     */
-    public function transformString(): void
-    {
-        $this->transformToString('string');
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function getIdProperty(): string
     {
         return 'entityId';
+    }
+
+    /**
+     * Defined setter for testage - protected so __call will run instead of this property.
+     *
+     * @param string $withSetter
+     *
+     * @return void
+     */
+    protected function setWithSetter(string $withSetter): void
+    {
+        $this->withSetter = $withSetter;
     }
 }

--- a/tests/TestCases/ORMTestCase.php
+++ b/tests/TestCases/ORMTestCase.php
@@ -20,8 +20,8 @@ use EoneoPay\Externals\Bridge\Laravel\Translator;
 use EoneoPay\Externals\Bridge\Laravel\Validator;
 use EoneoPay\Externals\Bridge\LaravelDoctrine\Extensions\ResolveTargetEntityExtension;
 use EoneoPay\Externals\Bridge\LaravelDoctrine\Extensions\SoftDeleteExtension;
-use EoneoPay\Externals\ORM\Entity;
 use EoneoPay\Externals\ORM\EntityManager;
+use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
 use EoneoPay\Externals\ORM\Interfaces\EntityManagerInterface;
 use EoneoPay\Externals\ORM\Listeners\GenerateUniqueValue;
 use EoneoPay\Externals\ORM\Subscribers\ValidateEventSubscriber;
@@ -224,11 +224,11 @@ abstract class ORMTestCase extends TestCase
      * Get entity contents via reflection, this is used so there's no reliance
      * on entity methods such as toArray for tests to work
      *
-     * @param \EoneoPay\Externals\ORM\Entity $entity The entity to get data from
+     * @param \EoneoPay\Externals\ORM\Interfaces\EntityInterface $entity The entity to get data from
      *
      * @return mixed[]
      */
-    protected function getEntityContents(Entity $entity): array
+    protected function getEntityContents(EntityInterface $entity): array
     {
         // Get properties available for this entity
         try {


### PR DESCRIPTION
This work extracts out basic __call functionality into a SimpleEntity that does not have any advanced features.

- SimpleEntity does not have fill(), and no constructor parameter to automatically accept an array of data
- SimpleEntity does not have any associate() methods, this should be manually handled in setters:
```php
function setCustomer(Customer $customer): void {
  $this->customer = $customer;
  $customer->setSubscription($this);
}
```
- SimpleEntity retains __call for magic getters, hassers and setters along with methods for building validation constraints inside getRules

The intention here is SimpleEntity is a stepping stone to removing the base entity entirely, but there is too much work to migrate from magic getters/setters to concrete ones in the current ticket.